### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/day07/src/part_a.rs
+++ b/day07/src/part_a.rs
@@ -4,7 +4,7 @@ Pattern number must be within [0, 2^(numbers.len() - 1))
 fn test_expression(numbers: &Vec<i64>, pattern_number: i32, width: usize, target: i64) -> bool {
     let mut numbers = numbers.iter();
     let mut res = *numbers.next().expect("Tried to test an empty expression!");
-    let mut pattern = format!("{pattern_number:.b}");
+    let mut pattern = format!("{pattern_number:b}");
     while pattern.len() < width {
         pattern.insert(0, '0');
     }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.